### PR TITLE
Fix support for :boot-jvm-options

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,18 @@
+BINARY_LOC := $(shell which boot || which boot.bak | sed "s/.bak//")
+
+echo:
+	echo ${BINARY_LOC}
+
+bin/boot.sh:
+	boot build standalone
+	cat src/head.sh target/bootstrap.uber.jar > bin/boot.sh
+	chmod +x bin/boot.sh
+
+install-boot-bin: bin/boot.sh
+	mv bin/boot.sh ${BINARY_LOC}
+	
+backup-boot-bin:
+	mv ${BINARY_LOC} ${BINARY_LOC}.bak
+	
+restore-boot-bin:
+	mv ${BINARY_LOC}.bak ${BINARY_LOC}

--- a/src/bootstrap.clj
+++ b/src/bootstrap.clj
@@ -55,7 +55,7 @@
 
 (defn- pin-version [version]
   (let [props (io/file (conf/work-dir) "boot.properties")]
-    (when (and (.exists ^File (io/file (conf/work-dir) "boot.properties"))
+    (when (and (.exists ^File props)
                (not= version (:boot-version (conf/project))))
       (println (format "Pinning BOOT_VERSION to %s..." version))
       (-> (props/load-properties props)

--- a/src/bootstrap.clj
+++ b/src/bootstrap.clj
@@ -63,8 +63,14 @@
 
 (defn- launch-version [version args]
   (let [jar     (.getAbsolutePath ^File (version-jar version))
-        command (:boot-java-command (conf/config) "java")
-        ^List args (into [command "-jar" jar] args)]
+        conf    (conf/config)
+        command (:boot-java-command conf "java")
+        jvm-options (some-> (get conf :boot-jvm-options) vector)
+        ^List args (into [command]
+                         (concat
+                          jvm-options
+                          ["-jar" jar]
+                          args))]
     (.waitFor (.start (.inheritIO (ProcessBuilder. args))))))
 
 (defn- print-version [config]


### PR DESCRIPTION
This patch fixes the use of the `:jvm-options` property (via one of the config options) [as documented in the WIKI](https://github.com/boot-clj/boot/wiki/JVM-Options)

## Testing 
Add `BOOT_JVM_OPTIONS=-XX:-OmitStackTraceInFastThrow` to your `boot.properties` file

Now start a `boot repl` and run this command:
```
(let [x (fn [] (/ nil 1)) cnt0 20000] (loop [cnt 0] (when-not (= cnt cnt0) (recur (try (x) (catch Exception e (print ".") (flush) (if (seq (.getStackTrace e)) (inc cnt) (do (println "No stacktrace at" cnt) cnt0))))))))
```

It will say "No stacktrace at ***", where the number is probably smaller than 10000.

Now compile boot again from this branch:
```
 make bin/boot.sh backup-boot-bin install-boot-bin
```

And the above steps will not give "No stacktrace at ***"

The old boot script can be reverted via

```
make restore-boot-bin
```